### PR TITLE
Allow nologin user to execute the script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -28,4 +28,4 @@ rpl "SECRET" "${SECRET}" /tmp/btsync.conf
 rpl "DEVICE" "${DEVICE}" /tmp/btsync.conf
 mkdir -p /btsync/.sync
 chown ${USER_NAME}.${USER_NAME} /btsync/.sync
-su $USER_NAME -c "btsync --config /tmp/btsync.conf --nodaemon"
+su -s /bin/bash -c "btsync --config /tmp/btsync.conf --nodaemon" $USER_NAME


### PR DESCRIPTION
Nologin user, such as internal "backup" user can't execute this script because it has no shell.
To compensate this, specify default shell.

CC: @timlinux 